### PR TITLE
Document dependency on libcppnetlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Below are instructions for Linux systems:
 
 First, install dependencies
 ```
-sudo apt-get install autotools-dev automake autoconf libtool pkg-config libprotobuf-dev protobuf-compiler python-protobuf libjsoncpp-dev libgoogle-glog-dev libgflags-dev libsnappy-dev libcurl4-openssl-dev
+sudo apt-get install autotools-dev automake autoconf libtool pkg-config libprotobuf-dev protobuf-compiler python-protobuf libjsoncpp-dev libgoogle-glog-dev libgflags-dev libsnappy-dev libcurl4-openssl-dev libcppnetlib-dev
 ```
 
 For compiling:


### PR DESCRIPTION
without libcppnetlib-dev installed,  <boost/network/uri.hpp> included by miw/log_format.cc will not be available. (Ubuntu 14.04)

libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I../../miw -I.. -pthread -Wall -g -pipe -std=c++11 -fpermissive -fopenmp -O2 -I../metis -fno-omit-frame-pointer -D_GNU_SOURCE -include ../config.h -DJTLS=__thread -DJSHARED_ATTR= -DJOS_CLINE=64 -DCACHE_LINE_SIZE=64 -DJOS_NCPU=4 -D__STDC_FORMAT_MACROS -g -O2 -MT log_format.lo -MD -MP -MF .deps/log_format.Tpo -c ../../miw/log_format.cc  -fPIC -DPIC -o .libs/log_format.o
../../miw/log_format.cc:34:33: fatal error: boost/network/uri.hpp: No such file or directory
 #include <boost/network/uri.hpp>
                                 ^
compilation terminated.
