### PR TITLE
field matching and/or conditions for filtering input logs before map-reduce operations

### DIFF
--- a/miw/log_definition.proto
+++ b/miw/log_definition.proto
@@ -21,6 +21,12 @@ message float_field
 	optional float holder = 2; /* for holding denominator in mean, etc.... */
 }
 
+message match_field
+{
+	required string match_str = 1;
+	optional string logic = 2 [default = "or"];
+}
+
 message field
 {
 	required string name = 1;
@@ -45,6 +51,7 @@ message field
 	optional string filter_type = 18;
 	optional string filter_field = 19;
 	optional string url_format = 20 [default = "%scheme://%host%port"]; /* special formatting for URLs (%scheme, %host, %port, %path, %query, %fragment) */
+	optional match_field match = 21;
 }
 
 message logdef


### PR DESCRIPTION
Support for field matching prior to computations.
Works as follows:
- every matching comes with a `match_str` string and `logic` indicating whether it is a `and` or `or` condition (default to `or`)
- `key` fields mandatory fallback to being an `and` condition
- matching is simple case-sensitive string inclusion, no regex or wildcards supported at the moment

Example in `json` format definition:

```
"name":"user",
"type":"string",
"key":true,
"match":
            {
            "match_str":"root",
            "logic":"and"
            }
```

limits computations to logs in which the `user` field contains `root`.
